### PR TITLE
EOF edits

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -28,10 +28,10 @@ from scipy.io import loadmat
 from scipy.linalg import block_diag
 
 from isofit.core.common import eps, svd_inv_sqrt
+from isofit.core.geometry import Geometry
 from isofit.core.instrument import Instrument
 from isofit.radiative_transfer.radiative_transfer import RadiativeTransfer
 from isofit.surface import Surface
-from isofit.core.geometry import Geometry
 
 Logger = logging.getLogger(__file__)
 
@@ -223,6 +223,14 @@ class ForwardModel:
 
         return block_diag(Sb_surface, Sb_RT, Sb_instrument)
 
+    def eof_offset(self, x_surface, x_RT, x_instrument):
+        """Empirical orthogonal fucntion offset. FM wrapper in the style
+        of xa, Sa, Seps in case we want to be able to extend this
+        across surface, RT, and instrument"""
+        offset = self.instrument.eof_offset(x_instrument)
+
+        return offset
+
     def calc_meas(self, x, geom, rfl=[]):
         """Calculate the model observation at instrument wavelengths."""
         # Unpack state vector - Copy to not change x fm-wide
@@ -264,7 +272,9 @@ class ForwardModel:
             geom=geom,
         )
 
-        return self.instrument.sample(x_instrument, self.RT.wl, rdn)
+        return self.instrument.sample(x_instrument, self.RT.wl, rdn) + self.eof_offset(
+            x_surface, x_RT, x_instrument
+        )
 
     def calc_Ls(self, x, geom):
         """Calculate the surface emission."""

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -147,7 +147,7 @@ def analytical_line(
         full_idx_surf_rfl,
         _,
         full_idx_RT,
-        _,
+        full_idx_instrument,
     ) = construct_full_state(config)
 
     # Perform the atmospheric interpolation
@@ -526,29 +526,22 @@ class Worker(object):
             # atm_interpolated file
             x_RT = self.rt_state[r, c, :]
 
+            # TODO depricate this iv_idx. Abstract the indexing a bit more
+            # s.t. we can smooth any statevector element by specifying idx
+            # iv_idx here is a relic from a version that
+            # achieved this by using atm_band_names in atm_interpolation
+            # need to improve that implementation
             iv_idx = self.fm.surface.analytical_iv_idx
-            inst_idx = self.fm.idx_instrument
-            x_instrument = self.subs_state[int(self.lbl[r, c, 0]), 0, inst_idx]
-            sub_state = self.subs_state[int(self.lbl[r, c, 0]), 0, iv_idx]
 
-            # Apply EOF adjustments to the radiance
-            if any(["EOF" in q for q in self.fm.statevec]):
-                si = 0
-                while True:
-                    sv_element = "EOF_%i" % (si + 1)
-                    if sv_element in self.fm.statevec:
-                        eof_idx = self.fm.statevec.index(sv_element)
-                        eof = self.fm.instrument.eof[:, si]
-                        meas = (
-                            meas
-                            - eof * self.subs_state[int(self.lbl[r, c, 0]), 0, eof_idx]
-                        )
-                        si += 1
-                    else:
-                        break
-
-            # Note: concatenation only works with the correct indexing.
-            sub_state = np.concatenate([sub_state, x_RT, x_instrument])
+            # Populate the "background" superpixel
+            lbl_idx = int(self.lbl[r, c, 0])
+            sub_state = np.zeros(self.fm.nstate)
+            sub_state[self.fm.idx_surface] = self.subs_state[lbl_idx, 0, iv_idx]
+            sub_state[self.fm.idx_RT] = x_RT
+            sub_state[self.fm.idx_instrument] = self.subs_state[
+                lbl_idx, 0, self.fm.idx_instrument
+            ]
+            # Enforce non-NaN
             sub_state[np.isnan(sub_state)] = self.fm.init[np.isnan(sub_state)]
 
             # Build statevector to use for initialization.


### PR DESCRIPTION
Changes:

1. Moves the EOF offset calculation into standalone functions. This can either be restricted to just `instrument` or include a wrapper call in `Forward` in the style of e.g. `xa`.
2. The EOF offset is _only_ applied two places now in the principle OE loop. One is on the output to the `calc_meas` call. The second is in `dmeas_dinstrument`. 
3. AOE now uses the `fm.eof_offset` function to calculate the offset at a given super-pixel value. The "shifted" measurement is calculated in `inverse_simple` instead of `analytical_line.py`
4. A small edit on the indexing within `analytical_line.py`, although this requires a dedicated PR and some work to better abstract and add in the ability to "smooth" any arbitrary state-vector element.


I did minimal testing. I used an example EOF file David provided to ensure that the EOF scale values moved around during inversion. I can't comment on the quality of the solutions. I also haven't deployed at the scene scale. I can test to confirm the AOE changes if need be.